### PR TITLE
Add flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ __pycache__/
 # other files
 *.log
 *.tar
+
+# other folders
+benchmark*/
+new*/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ Whichever test is being run, make sure the corresponding directory (new or bench
 
 The new or benchamrk directory will be created from the `replacement_directory` folder.
 
+## Data Download
+
+_As described in the `raw_nustar_download` directory._
+
+Download the data file through [here](https://heasarc.gsfc.nasa.gov/db-perl/W3Browse/w3table.pl?tablehead=name%3Dnumaster&Action=More+Options)
+
+For deafult behaviour that will behave with the provided GTI and REG files:
+
+- Search with ObsID: 80414202001
+- Select the observation, hit `Retrieve`, and then download the file from the link.
+
+If you download different data and/or want to use different GTI and/or REG files, that is fine, don't worry. Follow the help documentation for the shell script.
+
+## Usage
+
 ```bash
 A script to test an HEASoft install to a previous one.
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,87 @@ A repository to test an HEASoft install to a previous one.
 
 Things to consider **before running**:
 
-1. **Make sure** you have visited the `raw_nustar_download` directory and read the `README.md` file. We need a file _like_ `w3browse-68892.tar` in this directory containing the raw NuSTAR data.
-   1.  _The file name might be different. A quick fix is to rename the file to `w3browse-68892.tar`_.
+1. **Make sure** you have visited the `raw_nustar_download` directory and read the `README.md` file. We need a file _like_ `w3browse-68892.tar`, this can be placed in the `raw_nustar_download`.
 2. **Make sure** your HEASoft install has been sourced and you're in an appropriate Python environment (e.g., `conda create -n heasoft-test python matplotlib numpy astropy`)."
    1. _E.g., `source $HEADAS/headas-init.sh` and check that `which python3` prints out the Python interpreter of the right environment with the required packages._
-3. **Make sure** this script has appropriate permissions to run (e.g., `chmod 775 ./test_new_heasoft_install.sh`), although how you could see this and this instruction still being useful is beyond me."
+3. **Make sure** this script has appropriate permissions to run (e.g., `chmod 775 ./test_heasoft_install.sh`), although how you could see this and this instruction still being useful is beyond me."
 
-Run as `./test_new_heasoft_install.sh benchmark`:  
-
-* It will run HEASoft on your current configuration and store the outputs to then compare with a new, future HEASoft configuration (must be run first).
-Run as `./test_new_heasoft_install.sh new`:
-
-* It will compare the previous results to those obtained from the new currently installed HEASoft.
-  
-If you want the XSPEC results printed to the screen after the testing then include `print-result`;
-
-* I.e., `./test_new_heasoft_install.sh benchmark print-result` or `./test_new_heasoft_install.sh new print-result`.
+Run as `./test_heasoft_install.sh --help` or `./test_heasoft_install.sh -h` to get the usage documentation (also shown below).
 
 Whichever test is being run, make sure the corresponding directory (new or benchmark) doesn`t already exist as the code will produce a message and not run otherwise.
 
 The new or benchamrk directory will be created from the `replacement_directory` folder.
-Note, the result is logged in the log file regardless whether they are printed to the screen and benchmark must be run first.
+Note: The result is logged in the log file regardless whether they are printed to the screen and benchmark must be run first.
+
+```bash
+A script to test an HEASoft install to a previous one.
+
+Things to consider:
+ * Make sure you have visited the 'raw_nustar_download' directory and read the
+   'what2do.txt' file. We need a file _like_ 'w3browse-68892.tar' in this directory
+   containing the raw NuSTAR data (the download of the same data might have a
+   different name, just rename the file).
+ * Make sure your HEASoft install has been sourced ('source /path/to/headas-init.sh')
+   and you're in an appropriate Python environment, e.g.,
+   'conda create -n heasoft-test python matplotlib numpy astropy' and check with
+   'which python3').
+ * Make sure this script has appropriate permissions to run (e.g.,
+   'chmod 775 ./test_heasoft_install.sh'), although how you could see this and
+   this instruction still being useful is beyond me.
+
+Whichever test is being run, make sure the corresponding directory (new or benchmark)
+doesn't already exist as the code will produce a message and not run otherwise.
+
+The new or benchamrk directory will be created from the 'replacement_directory' folder.
+
+Note: The result is logged in the log file regardless whether they are printed to the
+screen and benchmark must be run first.
+
+Usage: $0 [OPTIONS]
+
+path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> [OPTIONS]
+
+Options:
+ -h ,  --help                Display this help message
+ -b*, --benchmark*           Define a benchmark run should be performed or folder
+                             name suffix to benchmark<suffix> to be used as a
+                             benchmark
+                                 - Default is \"benchmark\"
+                                 - If given an arument then it will be appended to
+                                   the benchmark folder name.
+ -n*, --new*                 Define a new run should be performed
+                                 - Default is \"new\"
+                                 - If given an arument then it will become the suffix
+                                   to the new run folder name (i.e., \"new<suffix>\").
+                                 - If both -b/--benchmark* and -n*/--new* are given
+                                   then a new run will be performed with the default
+                                   (or otherwise defined) benchmark folder
+ -g*, --gti-file*            Define a custom GTI file to use
+                                 - Default is:
+                                   \"$TIME_INTERVAL_FILE\"
+ -ra*, --rega-file*            Define a custom region FPMA file to use
+                                 - Default is:
+                                   \"$REGION_FILEA\"
+ -rb*, --regb-file*            Define a custom region FPMA file to use
+                                 - Default is:"
+                                   \"$REGION_FILEB\"
+ -o*, --obs-id*              Define a different NuSTAR observation ID
+                                 - Default is \"80414202001\"
+                                 - Must correspond to the <w3browse-*.tar> file that
+                                   was downloaded
+ -p , --print-xspec-result   Set that the final Xspec result should be printed
+
+Generic Eamples:
+## Run HEASoft on your current configuration, store the outputs, then compare with a new,
+## future HEASoft configuration (must be run first)
+path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -b
+
+## Compare previous results to those obtained from the new currently installed HEASoft
+path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -n
+
+Other Eamples:
+```
+
+## Known Issues
+
+Running the shell script not in its directory can cause an error within HEASoft due to long path legnths (especially when appending to either the "benchmark" or "new" directories being generated). Running ths script in its own directory can help with this, although running the same command again might work for some reason..

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ doesn't already exist as the code will produce a message and not run otherwise.
 
 The new or benchamrk directory will be created from the 'replacement_directory' folder.
 
-Note: The result is logged in the log file regardless whether they are printed to the
-screen and benchmark must be run first.
+Be aware of Path legnths, HEASoft does _not_ like long path lengths, but only sometimes.
 
 Usage: $0 [OPTIONS]
 
@@ -72,17 +71,42 @@ Options:
                                  - Default is \"80414202001\"
                                  - Must correspond to the <w3browse-*.tar> file that
                                    was downloaded
- -p , --print-xspec-result   Set that the final Xspec result should be printed
 
-Generic Eamples:
+Standard Eamples:"
+-----------------"
+## Get script description and usage
+path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -h
+
 ## Run HEASoft on your current configuration, store the outputs, then compare with a new,
 ## future HEASoft configuration (must be run first)
 path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -b
-
+"
 ## Compare previous results to those obtained from the new currently installed HEASoft
 path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -n
+"
+Fancier Eamples:
+----------------
+## Run a benchmark and save to a folder benchmark1
+path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -b 1
+## or equivalently"
+ - path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> --benchmark 1
 
-Other Eamples:
+## Run a new run and save to a folder new2024-08-23
+path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -n 2024-08-23
+
+## Run a new run and save to a folder new2024-09 and compare to a benchamrk folder
+## called benchmark2 (the order of the flags does not matter)
+path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -b 2 -n 2024-09
+
+## Run a new run and save to a folder new2024-081 and compare to a benchamrk folder
+## called benchmark1, while pointing to a new time interval and region files (the
+## order of the flags does not matter)
+path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -n 2024-081 -b 1\ 
+                                -g path/to/time_gti_file.fits -ra path/to/reg_file.reg\ 
+                                -rb path/to/reg_file.reg
+
+## Run a benchmark with downloaded data that has a different NuSTAR OBSID
+path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -b -o <new_data_OBSID>
 ```
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Run as `./test_heasoft_install.sh --help` or `./test_heasoft_install.sh -h` to g
 Whichever test is being run, make sure the corresponding directory (new or benchmark) doesn`t already exist as the code will produce a message and not run otherwise.
 
 The new or benchamrk directory will be created from the `replacement_directory` folder.
-Note: The result is logged in the log file regardless whether they are printed to the screen and benchmark must be run first.
 
 ```bash
 A script to test an HEASoft install to a previous one.
@@ -38,6 +37,9 @@ doesn't already exist as the code will produce a message and not run otherwise.
 The new or benchamrk directory will be created from the 'replacement_directory' folder.
 
 Be aware of Path legnths, HEASoft does _not_ like long path lengths, but only sometimes.
+
+Flags: Make sure to use the syntax `-flag <input>` (or just `-flag`, if appropriate) 
+and _not_ `-flag=<input>`.
 
 Usage: $0 [OPTIONS]
 
@@ -111,4 +113,4 @@ path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -b -o <new_data_OBSID>
 
 ## Known Issues
 
-Running the shell script not in its directory can cause an error within HEASoft due to long path legnths (especially when appending to either the "benchmark" or "new" directories being generated). Running ths script in its own directory can help with this, although running the same command again might work for some reason..
+1. Running the shell script not in its directory can cause an error within HEASoft due to long path legnths (especially when appending to either the "benchmark" or "new" directories being generated). Running ths script in its own directory can help with this, although running the same command again might work for some reason..

--- a/raw_nustar_download/README.md
+++ b/raw_nustar_download/README.md
@@ -9,11 +9,4 @@ For deafult behaviour:
 - Search with ObsID: 80414202001
 - Select the observation, hit `Retrieve`, and then download the file from the link.
 
-If you download different data and/or want to use different GTI and/or REG files, that is fine, don't worry. You just need to change the following variables in the shell script and follow the help documentation for the shell script:
-
-- And the file names in the `.xcm` files in the `5-xspec-test` directory
-  - e.g., `data 1:1 nu<OBSID>A06_cl_grade0_sr.pha 2:2 nu<OBSID>B06_cl_grade0_sr.pha`
-
-These fields are currently set to:
-
-- and, e.g., `data 1:1 nu80414202001A06_cl_grade0_sr.pha 2:2 nu80414202001B06_cl_grade0_sr.pha`
+If you download different data and/or want to use different GTI and/or REG files, that is fine, don't worry. Follow the help documentation for the shell script.

--- a/raw_nustar_download/README.md
+++ b/raw_nustar_download/README.md
@@ -4,19 +4,16 @@
 
 Download the data file through [here](https://heasarc.gsfc.nasa.gov/db-perl/W3Browse/w3table.pl?tablehead=name%3Dnumaster&Action=More+Options)
 
+For deafult behaviour:
+
 - Search with ObsID: 80414202001
 - Select the observation, hit `Retrieve`, and then download the file from the link.
 
-- If you download different data and/or want to use different GTI and/or REG files, that is fine, don't worry. You just need to change the following variables in the shell script:
-  - `DOWNLOADED_DATA`, `TIME_INTERVAL_FILE`, `REGION_FILE`, `OBSID`
-    - The `TIME_INTERVAL_FILE` and `REGION_FILE` files being pointed to live in `analysis_selections/good_time_interval/` and `analysis_selections/region/`, respectively
-  - And the file names in the `.xcm` files in the `5-xspec-test` directory
-    - e.g., `data 1:1 nu<OBSID>A06_cl_grade0_sr.pha 2:2 nu<OBSID>B06_cl_grade0_sr.pha`
+If you download different data and/or want to use different GTI and/or REG files, that is fine, don't worry. You just need to change the following variables in the shell script and follow the help documentation for the shell script:
+
+- And the file names in the `.xcm` files in the `5-xspec-test` directory
+  - e.g., `data 1:1 nu<OBSID>A06_cl_grade0_sr.pha 2:2 nu<OBSID>B06_cl_grade0_sr.pha`
 
 These fields are currently set to:
 
-- `DOWNLOADED_DATA="w3browse-68892.tar"`
-- `TIME_INTERVAL_FILE="time_gti"`
-- `REGION_FILE="reg_fpm"`
-- `OBSID="80414202001"`
 - and, e.g., `data 1:1 nu80414202001A06_cl_grade0_sr.pha 2:2 nu80414202001B06_cl_grade0_sr.pha`

--- a/replacement_directory/5-xspec-test/apec1fit_fpma_cstat.xcm
+++ b/replacement_directory/5-xspec-test/apec1fit_fpma_cstat.xcm
@@ -1,3 +1,4 @@
+
 ########################################################
 ## Fit one NuSTAR FPM with single thermal APEC model 
 ## with the new Feld 92A coronal abundances - this is actual solar coronal, unlike "abund feld" in xspec
@@ -10,7 +11,7 @@
 ########################################################
 
 ## Name of the pha file 
-data 1:1 nu80414202001A06_cl_grade0_sr.pha
+data 1:1 nu105A06_cl_grade0_sr.pha
 
 ## Use the c-stat for fitting 
 statistic cstat

--- a/replacement_directory/5-xspec-test/apec1fit_fpmab_cstat.xcm
+++ b/replacement_directory/5-xspec-test/apec1fit_fpmab_cstat.xcm
@@ -1,3 +1,4 @@
+
 ########################################################
 ## Fit two NuSTAR FPM with single thermal APEC model 
 ## with the new Feld 92A coronal abundances - this is actual solar coronal, unlike "abund feld" in xspec
@@ -10,7 +11,7 @@
 ########################################################
 
 ## Name of the pha files
-data 1:1 nu80414202001A06_cl_grade0_sr.pha 2:2 nu80414202001B06_cl_grade0_sr.pha
+data 1:1 nu105A06_cl_grade0_sr.pha 2:2 nu105B06_cl_grade0_sr.pha
 
 ## Use the c-stat for fitting 
 statistic cstat

--- a/replacement_directory/5-xspec-test/apec1fit_fpmb_cstat.xcm
+++ b/replacement_directory/5-xspec-test/apec1fit_fpmb_cstat.xcm
@@ -1,3 +1,4 @@
+
 ########################################################
 ## Fit one NuSTAR FPM with single thermal APEC model 
 ## with the new Feld 92A coronal abundances - this is actual solar coronal, unlike "abund feld" in xspec
@@ -10,7 +11,7 @@
 ########################################################
 
 ## Name of the pha file 
-data 1:1 nu80414202001B06_cl_grade0_sr.pha
+data 1:1 nu105B06_cl_grade0_sr.pha
 
 ## Use the c-stat for fitting 
 statistic cstat

--- a/replacement_directory/5-xspec-test/create_xcm.py
+++ b/replacement_directory/5-xspec-test/create_xcm.py
@@ -1,0 +1,224 @@
+import sys
+
+OBSID = sys.argv[1]
+
+apec1fit_fpma_cstat = f"""
+########################################################
+## Fit one NuSTAR FPM with single thermal APEC model 
+## with the new Feld 92A coronal abundances - this is actual solar coronal, unlike "abund feld" in xspec
+## Also using c-stat for fitting statistics - best choice when some low count bins
+## 
+##    Run as @apec1fit_fpm1_cstat.xcm in xspec, but manually need to do the last few lines in iplot
+## 
+## 18-Jan-2018 IGH Started based on earlier examples, originally coming from BG
+## 05-Mar-2019 KC Edited to change the ranges for fit and filename (personal use)
+########################################################
+
+## Name of the pha file 
+data 1:1 nu{OBSID}A06_cl_grade0_sr.pha
+
+## Use the c-stat for fitting 
+statistic cstat
+
+setplot energy
+
+## Fit over 2.5 to 7.4
+## for A 
+ignore *:0.-2.5 7.4-**
+
+cpd /xw
+plot
+
+## Choose APEC for the model, VAPEC basically the same as APEC, but more control over abundances (use "abund" command instead)
+## All models here https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/Models.html
+model apec
+/*
+
+renorm
+## Load in actual coronal abundances - "abund feld" is really photospheric!
+abund file feld92a_coronal0.txt
+fit 10000
+
+setplot xlog off
+plot ldata ratio
+
+## Show free parameters
+show free
+
+## Show fit values
+show fit
+
+## Want the errors calculated as well?
+## By default its 2.706\sig (90% conf) but want 1\sig 
+# error 1 4
+error 1.0 1 4
+
+## Write out the fit results
+## Careful as the following line will apend to this file if it already exists, instead of overwriting it
+writefits mod_apec1fit_fpma_cstat.fits
+
+
+notice *: 1.6-79.0
+
+## Write out the plot of the spectrum and fit
+## Need to run the next two lines manually
+
+#iplot ldata ufspec rat
+#wdata mod_apec1fit_fpma_cstat.txt
+#exit
+
+
+"""
+
+apec1fit_fpmb_cstat = f"""
+########################################################
+## Fit one NuSTAR FPM with single thermal APEC model 
+## with the new Feld 92A coronal abundances - this is actual solar coronal, unlike "abund feld" in xspec
+## Also using c-stat for fitting statistics - best choice when some low count bins
+## 
+##    Run as @apec1fit_fpm1_cstat.xcm in xspec, but manually need to do the last few lines in iplot
+## 
+## 18-Jan-2018 IGH Started based on earlier examples, originally coming from BG
+## 05-Mar-2019 KC Edited to change the ranges for fit and filename (personal use)
+########################################################
+
+## Name of the pha file 
+data 1:1 nu{OBSID}B06_cl_grade0_sr.pha
+
+## Use the c-stat for fitting 
+statistic cstat
+
+setplot energy
+
+## Fit over 2.5 to 7
+## for A 
+ignore *:0.-2.5 7.0-**
+
+cpd /xw
+plot
+
+## Choose APEC for the model, VAPEC basically the same as APEC, but more control over abundances (use "abund" command instead)
+## All models here https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/Models.html
+model apec
+/*
+
+renorm
+## Load in actual coronal abundances - "abund feld" is really photospheric!
+abund file feld92a_coronal0.txt
+fit 10000
+
+setplot xlog off
+plot ldata ratio
+
+## Show free parameters
+show free
+
+## Show fit values
+show fit
+
+## Want the errors calculated as well?
+## By default its 2.706\sig (90% conf) but want 1\sig 
+# error 1 4
+error 1.0 1 4
+
+## Write out the fit results
+## Careful as the following line will apend to this file if it already exists, instead of overwriting it
+writefits mod_apec1fit_fpmb_cstat.fits
+
+
+notice *: 1.6-79.0
+
+## Write out the plot of the spectrum and fit
+## Need to run the next two lines manually
+
+#iplot ldata ufspec rat
+#wdata mod_apec1fit_fpmb_cstat.txt
+#exit
+
+
+"""
+
+apec1fit_fpmab_cstat = f"""
+########################################################
+## Fit two NuSTAR FPM with single thermal APEC model 
+## with the new Feld 92A coronal abundances - this is actual solar coronal, unlike "abund feld" in xspec
+## Also using c-stat for fitting statistics - best choice when some low count bins
+## 
+##    Run as @apec2fit_fpm1_cstat_prb.xcm in xspec, but manually need to do the last few lines in iplot
+## 
+## 18-Jan-2018 IGH Started based on earlier examples from BG
+## 05-Mar-2019 KC Edited to change the ranges for fit and filename (personal use)
+########################################################
+
+## Name of the pha files
+data 1:1 nu{OBSID}A06_cl_grade0_sr.pha 2:2 nu{OBSID}B06_cl_grade0_sr.pha
+
+## Use the c-stat for fitting 
+statistic cstat
+
+## Fit over 2.5 to 8
+ignore *:0.-2.5 7.4-**
+
+## Plot the data to check it looks ok
+setplot energy
+cpd /xw
+plot
+
+## Choose APEC for the model, VAPEC basically the same as APEC, but more control over abundances (use "abund" command instead)
+## All models here https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/Models.html
+## Also have multiplicative const factor to fit for FPMB (covers systematic diff between A and B)
+model const*apec
+1.0 -0.1
+/*
+
+## Only want the constant for FPMB to vary, and independent of FPMA fit
+untie 6
+thaw 6
+
+renorm
+## Load in actual coronal abundances - "abund feld" is really photospheric!
+abund file feld92a_coronal0.txt
+fit 10000
+
+## Plot the fit to the data
+setplot group 1-2
+setplot add
+setplot xlog off
+plot ldata ratio
+
+## Show free parameters
+show free
+
+## Show fit values
+show fit
+
+## Want the errors calculated as well 
+## By default its 2.706\sig (90% conf) but want 1\sig 
+#error 2 5 6
+error 1.0 2 5 6
+
+## Write out the fit results
+## Careful as the following line will apend to this file if it already exists, instead of overwriting it
+writefits mod_apec1fit_fpmab_cstat.fits
+
+notice *: 1.6-79.0
+
+## Write out the plot of the spectrum and fit
+## Need to run the next two lines manually
+
+#iplot ldata ufspec rat
+#wdata mod_apec1fit_fpmab_cstat.txt
+#exit
+
+
+"""
+
+def write_to_xcm(name, contents):
+    with open(f"{name}.xcm", "w") as file:
+        # Writing data to a file
+        file.write(contents)
+
+if __name__=="__main__":
+    write_to_xcm("apec1fit_fpma_cstat", apec1fit_fpma_cstat)
+    write_to_xcm("apec1fit_fpmb_cstat", apec1fit_fpmb_cstat)
+    write_to_xcm("apec1fit_fpmab_cstat", apec1fit_fpmab_cstat)

--- a/replacement_directory/5-xspec-test/runXspec.py
+++ b/replacement_directory/5-xspec-test/runXspec.py
@@ -1,5 +1,3 @@
-import matplotlib.pyplot as plt
-
 from subprocessXspec import XSPECfit
 
 

--- a/replacement_directory/6-xspec-test-result/getXspecParameters.py
+++ b/replacement_directory/6-xspec-test-result/getXspecParameters.py
@@ -1,4 +1,3 @@
-import matplotlib.pyplot as plt
 import sys
 
 from plots import xspecParams
@@ -22,16 +21,16 @@ if __name__=="__main__":
         _space = " "*10
 
         if str(sys.argv[1])=="compare":
-            bench_fitting_values = xspecParams(f"../../benchmark/6-xspec-test-result/{_pf}.fits", *_to_check)
+            bench_fitting_values = xspecParams(f"../../{sys.argv[2]}/6-xspec-test-result/{_pf}.fits", *_to_check)
             _bench_fitting_values = {param:value[0] for (param,value) in bench_fitting_values.items() if ((not param.startswith("E")) and (param not in ["emfact",'kev2mk']))}
             print(f"{_pf}.fits result:")
-            print(f"Param".ljust(_l//2)+_space+"Benchmark".ljust(_l)+_space+"New".ljust(_l))
+            print("Param".ljust(_l//2)+_space+"Benchmark".ljust(_l)+_space+"New".ljust(_l))
             for p in _bench_fitting_values.keys():
                 print(f"{p.ljust(_l//2)}:{_space}{str(_bench_fitting_values[p]).ljust(_l)}{_space}{str(_fitting_values[p]).ljust(_l)}")
             print("\n")
         else:
             print(f"{_pf}.fits result:")
-            print(f"Param".ljust(_l//2)+_space+"Benchmark".ljust(_l))
+            print("Param".ljust(_l//2)+_space+"Benchmark".ljust(_l))
             for p in _fitting_values.keys():
                 print(f"{p.ljust(_l//2)}:{_space}{str(_fitting_values[p]).ljust(_l)}")
             print("\n")

--- a/test_heasoft_install.sh
+++ b/test_heasoft_install.sh
@@ -74,6 +74,9 @@ function usage() {
     echo ""
     echo "Be aware of Path legnths, HEASoft does _not_ like long path lengths, but only sometimes."
     echo ""
+    echo "Flags: Make sure to use the syntax \`-flag <input>\` (or just \`-flag\`, if appropriate)"
+    echo "and _not_ \`-flag=<input>\`."
+    echo ""
     echo "Usage: $0 [OPTIONS]"
     echo ""
     echo "path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> [OPTIONS]"
@@ -368,6 +371,7 @@ normal_line cp "./nu"$OBSID"B06_cl_grade0_sr.pha" $SCRIPT_DIR$HEASOFT_OUTPUT_FIL
 normal_line cp "./nu"$OBSID"B06_cl_grade0_sr.arf" $SCRIPT_DIR$HEASOFT_OUTPUT_FILE"/5-xspec-test/"
 normal_line cp "./nu"$OBSID"B06_cl_grade0_sr.rmf" $SCRIPT_DIR$HEASOFT_OUTPUT_FILE"/5-xspec-test/"
 normal_line cd $SCRIPT_DIR$HEASOFT_OUTPUT_FILE"/5-xspec-test/"
+normal_line python3  "create_xcm.py" $OBSID
 normal_lines_end
 
 # fit the data, testing XSPEC

--- a/test_heasoft_install.sh
+++ b/test_heasoft_install.sh
@@ -1,24 +1,22 @@
 #!/bin/zsh
 
 # may need to: conda create -n heasoft-test python matplotlib numpy astropy
-# and also: chmod 775 ./test_new_heasoft_install.sh
+# and also: chmod 775 ./test_heasoft_install.sh
 
-# run ./test_new_heasoft_install.sh help
+# run ./test_heasoft_install.sh help
 # A script to test an HEASoft install to a previous one. 
-# Run as `./test_new_heasoft_install.sh benchmark`
+# Run as `./test_heasoft_install.sh benchmark`
 #       It will run HEASoft on your current configuration and store the outputs to then compare with a new, future HEASoft configuration.
-# Run as `./test_new_heasoft_install.sh new`
+# Run as `./test_heasoft_install.sh new`
 #       It will compare the previous results to those obtained from the new currently installed HEASoft.
 # If you want the XSPEC results printed to the screen after the testing then include 'print-result'; 
-#       I.e., `./test_new_heasoft_install.sh benchmark print-result` or `./test_new_heasoft_install.sh new print-result`.
+#       I.e., `./test_heasoft_install.sh benchmark print-result` or `./test_heasoft_install.sh new print-result`.
 # The result is logged in the log file regardless whether they are printed to the screen.
 
 #  change to the main directory to work in
 SCRIPT_DIR=$( cd -- "$( dirname -- "${(%):-%N}" )" &> /dev/null && pwd )
 
 # set up some defaults
-DOWNLOADED_DATA=$1 # "w3browse-68892.tar"
-DOWNLOADED_DATA_FILE=$(basename "$DOWNLOADED_DATA")
 TIME_INTERVAL_FILE=$SCRIPT_DIR"/analysis_selections/good_time_interval/time_gti.fits"
 REGION_FILEA=$SCRIPT_DIR"/analysis_selections/region/reg_fpma.reg"
 REGION_FILEB=$SCRIPT_DIR"/analysis_selections/region/reg_fpmb.reg"
@@ -42,35 +40,12 @@ function check_benchmark() {
     else
         echo "Benchmark files do not exist. Please try to populate benchmark files in the"
         echo "'$SCRIPT_DIR'"
-        echo "Run path/to/test_new_heasoft_install.sh with -h or --help for instructions."
+        echo "Run path/to/test_heasoft_install.sh with -h or --help for instructions."
         exit 1
     fi
 }
 
 BEGIN_STATEMENT="HEASoft should already be initialised by you, "
-# run as ./test_new_heasoft_install.sh -h and the $1 here is -h, use flags to either run current HEASoft install or to test files made from new HEASoft configuration against files from the old/current configuration 
-if [[ $1 = "benchmark" ]]
-then
-    # Get benchmark for how HEASoft should be
-    TERM_OUTFILE=$SCRIPT_DIR"/run_benchmark_heasoft_install.log"
-    HEASOFT_OUTPUT_FILE="/benchmark"
-    COMPARE_TO_BENCHMARK="no"
-    dir_exist_check $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
-    echo $BEGIN_STATEMENT"starting HEASoft install to create cached examples." | tee $TERM_OUTFILE 2>&1
-elif [[ $1 = "new" ]]
-then
-    # Test new configuration
-    TERM_OUTFILE=$SCRIPT_DIR"/test_new_heasoft_install.log"
-    HEASOFT_OUTPUT_FILE="/new"
-    COMPARE_TO_BENCHMARK="yes"
-    dir_exist_check $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
-    check_benchmark $SCRIPT_DIR"/benchmark"
-    echo $BEGIN_STATEMENT"starting HEASoft processing to test against cached examples." | tee $TERM_OUTFILE 2>&1
-else
-    echo "Please run 'path/to/test_new_heasoft_install.sh -h' or"
-    echo "'path/to/test_new_heasoft_install.sh --help'."
-    exit 1
-fi
 
 function usage() {
     echo ""
@@ -86,7 +61,7 @@ function usage() {
     echo "   'conda create -n heasoft-test python matplotlib numpy astropy' and check with"
     echo "   'which python3')."
     echo " * Make sure this script has appropriate permissions to run (e.g.,"
-    echo "   'chmod 775 ./test_new_heasoft_install.sh'), although how you could see this and"
+    echo "   'chmod 775 ./test_heasoft_install.sh'), although how you could see this and"
     echo "   this instruction still being useful is beyond me."
     echo ""
     echo "Whichever test is being run, make sure the corresponding directory (new or benchmark)"
@@ -99,7 +74,7 @@ function usage() {
     echo ""
     echo "Usage: $0 [OPTIONS]"
     echo ""
-    echo "path/to/test_new_heasoft_install.sh <path/to/w3browse-*.tar> [OPTIONS]"
+    echo "path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> [OPTIONS]"
     echo ""
     echo "Options:"
     echo " -h ,  --help                Display this help message"
@@ -134,13 +109,21 @@ function usage() {
     echo "Generic Eamples:"
     echo "## Run HEASoft on your current configuration, store the outputs, then compare with a new,"
     echo "## future HEASoft configuration (must be run first)"
-    echo "path/to/test_new_heasoft_install.sh <path/to/w3browse-*.tar> -b"
+    echo "path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -b"
     echo ""
     echo "## Compare previous results to those obtained from the new currently installed HEASoft"
-    echo "path/to/test_new_heasoft_install.sh <path/to/w3browse-*.tar> -n"
+    echo "path/to/test_heasoft_install.sh <path/to/w3browse-*.tar> -n"
     echo ""
     echo "Other Eamples:"
     echo ""
+}
+
+function err() {
+    echo "Error in use."
+    echo "Please run:"
+    echo " - 'path/to/test_heasoft_install.sh -h', or"
+    echo " - 'path/to/test_heasoft_install.sh --help'."
+    exit 1
 }
 
 # \e[<fg_bg>;5;<ANSI_color_code>m
@@ -218,7 +201,7 @@ function handle_options() {
                 ;;
             -n* | --new*)
                 # Test new configuration
-                TERM_OUTFILE=$SCRIPT_DIR"/test_new_heasoft_install.log"
+                TERM_OUTFILE=$SCRIPT_DIR"/test_heasoft_install.log"
                 COMPARE_TO_BENCHMARK="yes"
                 echo $BEGIN_STATEMENT"starting HEASoft processing to test against cached examples." | tee $TERM_OUTFILE 2>&1
 
@@ -264,6 +247,9 @@ function handle_options() {
             -p | --print-xspec-result)
                 PRINT_XSPEC_RESULT=1
                 ;;
+            *)
+                err
+                ;;
         esac
         shift
     done
@@ -271,6 +257,12 @@ function handle_options() {
 
 ## go through the inputs and set things up
 handle_options "$@"
+
+DOWNLOADED_DATA=$1 # "w3browse-68892.tar"
+DOWNLOADED_DATA_FILE=$(basename "$DOWNLOADED_DATA")
+if [[ $DOWNLOADED_DATA = "" ]] then
+    err
+fi
 
 # if it's a new run, make sure the benchmark dir being pointed to exists
 if [[ $COMPARE_TO_BENCHMARK = "yes" ]] then

--- a/test_heasoft_install.sh
+++ b/test_heasoft_install.sh
@@ -333,16 +333,15 @@ check_obsid_dir $OBSID
 normal_line cd $OBSID 
 normal_lines_end
 
-
 # test nupipeline
-test_line "Get orbit and CHU EVT files (nupipeline)" "nupipeline obsmode=SCIENCE_SC indir=$FIRST_FILES_DIR/$OBSID steminputs=nu$OBSID outdir=event_cl entrystage=1 exitstage=2 pntra=OBJECT pntdec=OBJECT statusexpr=$STATUSEXPR cleanflick=no hkevtexpr=NONE clobber=yes runsplitsc=yes splitmode=STRICT" 1
+test_line "Get orbit and CHU EVT files (nupipeline)     " "nupipeline obsmode=SCIENCE_SC indir=$FIRST_FILES_DIR/$OBSID steminputs=nu$OBSID outdir=event_cl entrystage=1 exitstage=2 pntra=OBJECT pntdec=OBJECT statusexpr=$STATUSEXPR cleanflick=no hkevtexpr=NONE clobber=yes runsplitsc=yes splitmode=STRICT" 1
 
 # move directory to where the event files are
 normal_line cd "./event_cl"
 
 # screen the event files, testing nuscreen
-test_line "Screen counts to grade 0 (FPMA, nuscreen)" "nuscreen infile=nu"$OBSID"A06_cl.evt gtiscreen=no evtscreen=yes gtiexpr=NONE gradeexpr=0 statusexpr=NONE outdir="$SCRIPT_DIR$HEASOFT_OUTPUT_FILE"/3-nuscreen-test/ hkfile=./nu"$OBSID"A_fpm.hk outfile=nu"$OBSID"A06_cl_grade0.evt" 2a
-test_line "Screen counts to grade 0 (FPMB, nuscreen)" "nuscreen infile=nu"$OBSID"B06_cl.evt gtiscreen=no evtscreen=yes gtiexpr=NONE gradeexpr=0 statusexpr=NONE outdir="$SCRIPT_DIR$HEASOFT_OUTPUT_FILE"/3-nuscreen-test/ hkfile=./nu"$OBSID"B_fpm.hk outfile=nu"$OBSID"B06_cl_grade0.evt" 2b
+test_line "Screen counts to grade 0 (FPMA, nuscreen)   " "nuscreen infile=nu"$OBSID"A06_cl.evt gtiscreen=no evtscreen=yes gtiexpr=NONE gradeexpr=0 statusexpr=NONE outdir="$SCRIPT_DIR$HEASOFT_OUTPUT_FILE"/3-nuscreen-test/ hkfile=./nu"$OBSID"A_fpm.hk outfile=nu"$OBSID"A06_cl_grade0.evt" 2a
+test_line "Screen counts to grade 0 (FPMB, nuscreen)   " "nuscreen infile=nu"$OBSID"B06_cl.evt gtiscreen=no evtscreen=yes gtiexpr=NONE gradeexpr=0 statusexpr=NONE outdir="$SCRIPT_DIR$HEASOFT_OUTPUT_FILE"/3-nuscreen-test/ hkfile=./nu"$OBSID"B_fpm.hk outfile=nu"$OBSID"B06_cl_grade0.evt" 2b
 
 # get ready to filter with time and space so move the files needed to de-clutter
 echo $MOVING_STUFF_LINE >> $TERM_OUTFILE 2>&1
@@ -375,7 +374,7 @@ normal_line python3  "create_xcm.py" $OBSID
 normal_lines_end
 
 # fit the data, testing XSPEC
-test_line "Run XSPEC code (xspec)" "python3 runXspec.py" 4 "See log files in "$SCRIPT_DIR$HEASOFT_OUTPUT_FILE"5-xspec-test directory."
+test_line "Run XSPEC code (xspec)                       " "python3 runXspec.py" 4 "See log files in "$SCRIPT_DIR$HEASOFT_OUTPUT_FILE"5-xspec-test directory."
 
 # take the products from fitting, read to be plotted
 echo $MOVING_STUFF_LINE >> $TERM_OUTFILE 2>&1
@@ -389,7 +388,7 @@ normal_line cd $SCRIPT_DIR$HEASOFT_OUTPUT_FILE"/6-xspec-test-result/"
 normal_lines_end
 
 # plot the fits to the data, testing the output of xspec makes sense
-test_line "Plot XSPEC result (xspec)" "python3 plotXspec.py" 5 "See plots in "$SCRIPT_DIR$HEASOFT_OUTPUT_FILE"6-xspec-test-result directory."
+test_line "Plot XSPEC result (xspec)                    " "python3 plotXspec.py" 5 "See plots in "$SCRIPT_DIR$HEASOFT_OUTPUT_FILE"6-xspec-test-result directory."
 
 # record the results other than just in the plots, can output to terminal too if 'print-result'is given too
 XSPEC_RESULT_LINE="XSPEC Results:"

--- a/test_heasoft_install.sh
+++ b/test_heasoft_install.sh
@@ -247,9 +247,6 @@ function handle_options() {
             -p | --print-xspec-result)
                 PRINT_XSPEC_RESULT=1
                 ;;
-            *)
-                err
-                ;;
         esac
         shift
     done

--- a/test_heasoft_install.sh
+++ b/test_heasoft_install.sh
@@ -22,6 +22,7 @@ REGION_FILEA=$SCRIPT_DIR"/analysis_selections/region/reg_fpma.reg"
 REGION_FILEB=$SCRIPT_DIR"/analysis_selections/region/reg_fpmb.reg"
 OBSID="80414202001"
 BENCHMARK_DIR=$SCRIPT_DIR"/benchmark"
+BENCHMARK_DIR_EXT=""
 COMPARE_TO_BENCHMARK="no"
 PRINT_XSPEC_RESULT=0
 
@@ -131,8 +132,8 @@ function err() {
 # <ANSI_color_code> if 0--255
 DEFAULT_C="\e[0m"
 RUNNING_C="\e[48;5;30m"
-PASSED_C="\e[48;5;10m"
-FAILED_C="\e[48;5;9m"
+PASSED_C="\e[48;5;148m"
+FAILED_C="\e[48;5;1m"
 
 function test_line() {
     ## save me from writing out running/passed/failed and file management all the time
@@ -193,22 +194,22 @@ function handle_options() {
                 exit 0
                 ;;
             -b* | --benchmark*)
-                if ! has_argument $@; then
-                    BENCHMARK_DIR="/benchmark"
-                else
+                if has_argument $@; then
                     BENCHMARK_DIR="/benchmark"$(extract_argument $@)
+                    BENCHMARK_DIR_EXT=$(extract_argument $@)
                 fi
                 ;;
             -n* | --new*)
                 # Test new configuration
-                TERM_OUTFILE=$SCRIPT_DIR"/test_heasoft_install.log"
                 COMPARE_TO_BENCHMARK="yes"
                 echo $BEGIN_STATEMENT"starting HEASoft processing to test against cached examples." | tee $TERM_OUTFILE 2>&1
 
                 if ! has_argument $@; then
                     HEASOFT_OUTPUT_FILE="/new"
+                    TERM_OUTFILE=$SCRIPT_DIR"/run_new_heasoft_install.log"
                 else
                     HEASOFT_OUTPUT_FILE="/new"$(extract_argument $@)
+                    TERM_OUTFILE=$SCRIPT_DIR"/run_new"$(extract_argument $@)"_heasoft_install.log"
                 fi
                 dir_exist_check $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
                 ;;
@@ -267,9 +268,9 @@ if [[ $COMPARE_TO_BENCHMARK = "yes" ]] then
 else
     # Get benchmark for how HEASoft should be
     # only want to run this is -n is not given
-    TERM_OUTFILE=$SCRIPT_DIR"/run_benchmark_heasoft_install.log"
+    TERM_OUTFILE=$SCRIPT_DIR"/run_benchmark"$BENCHMARK_DIR_EXT"_heasoft_install.log"
     echo $BEGIN_STATEMENT"starting HEASoft install to create cached examples." | tee $TERM_OUTFILE 2>&1
-    $HEASOFT_OUTPUT_FILE=$BENCHMARK_DIR
+    HEASOFT_OUTPUT_FILE=$BENCHMARK_DIR
     dir_exist_check $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
 fi
 

--- a/test_heasoft_install.sh
+++ b/test_heasoft_install.sh
@@ -21,7 +21,7 @@ TIME_INTERVAL_FILE=$SCRIPT_DIR"/analysis_selections/good_time_interval/time_gti.
 REGION_FILEA=$SCRIPT_DIR"/analysis_selections/region/reg_fpma.reg"
 REGION_FILEB=$SCRIPT_DIR"/analysis_selections/region/reg_fpmb.reg"
 OBSID="80414202001"
-BENCHMARK_DIR=$SCRIPT_DIR"/benchmark"
+BENCHMARK_DIR="/benchmark"
 BENCHMARK_DIR_EXT=""
 COMPARE_TO_BENCHMARK="no"
 PRINT_XSPEC_RESULT=0
@@ -132,7 +132,7 @@ function err() {
 # <ANSI_color_code> if 0--255
 DEFAULT_C="\e[0m"
 RUNNING_C="\e[48;5;30m"
-PASSED_C="\e[48;5;148m"
+PASSED_C="\e[48;5;28m"
 FAILED_C="\e[48;5;1m"
 
 function test_line() {
@@ -264,7 +264,7 @@ fi
 
 # if it's a new run, make sure the benchmark dir being pointed to exists
 if [[ $COMPARE_TO_BENCHMARK = "yes" ]] then
-    check_benchmark $BENCHMARK_DIR
+    check_benchmark $SCRIPT_DIR$BENCHMARK_DIR
 else
     # Get benchmark for how HEASoft should be
     # only want to run this is -n is not given
@@ -280,7 +280,7 @@ echo "Run Date & Time: "$(date +%d.%m.%y-%H:%M:%S) | tee -a $TERM_OUTFILE 2>&1
 
 #  only need dir structure so instead of selecting specific files to keep just delete all and replace with the bones of the structure again
 echo "\n\n" >> $TERM_OUTFILE 2>&1
-cp -R $SCRIPT_DIR"/replacement_directory" $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
+normal_line cp -R $SCRIPT_DIR"/replacement_directory" $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
 echo "\n\n" >> $TERM_OUTFILE 2>&1
 
 # some other variables
@@ -360,12 +360,12 @@ if [[ $COMPARE_TO_BENCHMARK = "yes" ]]
 then
     # compare the 'new' HEASoft install to the benchark
     echo $XSPEC_RESULT_LINE >> $TERM_OUTFILE 2>&1
-    normal_line python3 "getXspecParameters.py" "compare" "$$BENCHMARK_DIR"
+    normal_line python3 "getXspecParameters.py" "compare" "$BENCHMARK_DIR"
     normal_lines_end
     if [[ $PRINT_XSPEC_RESULT = 1 ]]
     then
         echo $XSPEC_RESULT_LINE 
-        python3 "getXspecParameters.py" "compare" "$$BENCHMARK_DIR"
+        python3 "getXspecParameters.py" "compare" "$BENCHMARK_DIR"
     fi
 else
     # Just run the benchmark so nothing to compare to

--- a/test_new_heasoft_install.sh
+++ b/test_new_heasoft_install.sh
@@ -16,6 +16,17 @@
 #  change to the main directory to work in
 SCRIPT_DIR=$( cd -- "$( dirname -- "${(%):-%N}" )" &> /dev/null && pwd )
 
+# set up some defaults
+DOWNLOADED_DATA=$1 # "w3browse-68892.tar"
+DOWNLOADED_DATA_FILE=$(basename "$DOWNLOADED_DATA")
+TIME_INTERVAL_FILE=$SCRIPT_DIR"/analysis_selections/good_time_interval/time_gti.fits"
+REGION_FILEA=$SCRIPT_DIR"/analysis_selections/region/reg_fpma.reg"
+REGION_FILEB=$SCRIPT_DIR"/analysis_selections/region/reg_fpmb.reg"
+OBSID="80414202001"
+BENCHMARK_DIR=$SCRIPT_DIR"/benchmark"
+COMPARE_TO_BENCHMARK="no"
+PRINT_XSPEC_RESULT=0
+
 function dir_exist_check() {
     # if this dir exists then don't want to overwrite so produce warning for user to delete if necessary
     if [ -d "$1" ]; then
@@ -29,7 +40,9 @@ function check_benchmark() {
     # Note: both 'benchmark' and 'new'should be exactly the same structure etc. However, the 'new'will just be compared to 'benchmark' at the end
     if [ -d $1 ]; then
     else
-        echo "Benchmark files do not exist. Please try to populate benchmark files in the '$SCRIPT_DIR' directory by running as './test_new_heasoft_install.sh benchmark' first and try again."
+        echo "Benchmark files do not exist. Please try to populate benchmark files in the"
+        echo "'$SCRIPT_DIR'"
+        echo "Run path/to/test_new_heasoft_install.sh with -h or --help for instructions."
         exit 1
     fi
 }
@@ -53,37 +66,82 @@ then
     dir_exist_check $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
     check_benchmark $SCRIPT_DIR"/benchmark"
     echo $BEGIN_STATEMENT"starting HEASoft processing to test against cached examples." | tee $TERM_OUTFILE 2>&1
-elif [[ $1 = "help" ]]
-then
-    echo "A script to test an HEASoft install to a previous one."
-    echo "Things to consider:"
-    echo "* Make sure you have visited the 'raw_nustar_download' directory and read the 'what2do.txt' file. We need a file _like_ 'w3browse-68892.tar' in this directory containing the raw NuSTAR data (the download of the same data might have a different name, just rename the file)."
-    echo "* Make sure your HEASoft install has been sourced ('source $HEADAS/headas-init.sh') and you're in an appropriate Python environment (e.g., 'conda create -n heasoft-test python matplotlib numpy astropy' and check with 'which python3')."
-    echo "* Make sure this script has appropriate permissions to run (e.g., 'chmod 775 ./test_new_heasoft_install.sh'), although how you could see this and this instruction still being useful is beyond me."
-    echo ""
-    echo "Run as './test_new_heasoft_install.sh benchmark':\n   * It will run HEASoft on your current configuration and store the outputs to then compare with a new, future HEASoft configuration (must be run first)."
-    echo "Run as './test_new_heasoft_install.sh new':\n   * It will compare the previous results to those obtained from the new currently installed HEASoft."
-    echo "If you want the XSPEC results printed to the screen after the testing then include 'print-result';\n   *I.e., './test_new_heasoft_install.sh benchmark print-result' or './test_new_heasoft_install.sh new print-result'."
-    echo "Whichever test is being run, make sure the corresponding directory (new or benchmark) doesn't already exist as the code will produce a message and not run otherwise."
-    echo "The new or benchamrk directory will be created from the 'replacement_directory' folder."
-    echo "Note, the result is logged in the log file regardless whether they are printed to the screen and benchmark must be run first."
-    exit 1
 else
-    echo "Please run './test_new_heasoft_install.sh help' or just go with the following."
-    echo "Run as either:\n   *'./test_new_heasoft_install.sh benchmark' to populate folder with a \"standard\" HEASoft run.\n   *'./test_new_heasoft_install.sh new' to test new HEASoft against the \"standard\" HEASoft."
-    echo "To print the XSPEC result instead of it just being shown in the log-file, include 'print-result':\n   *'./test_new_heasoft_install.sh benchmark print-result' or,\n   *'./test_new_heasoft_install.sh new print-result'."
-    echo "Note, the benchmark must be run first."
+    echo "Please run 'path/to/test_new_heasoft_install.sh -h' or"
+    echo "'path/to/test_new_heasoft_install.sh --help'."
     exit 1
 fi
 
-# add some stuff to terminal and log files
-echo "Testing will be based on the succesful execution of the code and final XSPEC results." | tee -a $TERM_OUTFILE 2>&1
-echo "Run Date & Time: "$(date +%d.%m.%y-%H:%M:%S) | tee -a $TERM_OUTFILE 2>&1
-
-#  only need dir structure so instead of selecting specific files to keep just delete all and replace with the bones of the structure again
-echo "\n\n" >> $TERM_OUTFILE 2>&1
-cp -R $SCRIPT_DIR"/replacement_directory" $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
-echo "\n\n" >> $TERM_OUTFILE 2>&1
+function usage() {
+    echo ""
+    echo "A script to test an HEASoft install to a previous one."
+    echo ""
+    echo "Things to consider:"
+    echo " * Make sure you have visited the 'raw_nustar_download' directory and read the"
+    echo "   'what2do.txt' file. We need a file _like_ 'w3browse-68892.tar' in this directory"
+    echo "   containing the raw NuSTAR data (the download of the same data might have a"
+    echo "   different name, just rename the file)."
+    echo " * Make sure your HEASoft install has been sourced ('source /path/to/headas-init.sh')"
+    echo "   and you're in an appropriate Python environment, e.g.,"
+    echo "   'conda create -n heasoft-test python matplotlib numpy astropy' and check with"
+    echo "   'which python3')."
+    echo " * Make sure this script has appropriate permissions to run (e.g.,"
+    echo "   'chmod 775 ./test_new_heasoft_install.sh'), although how you could see this and"
+    echo "   this instruction still being useful is beyond me."
+    echo ""
+    echo "Whichever test is being run, make sure the corresponding directory (new or benchmark)"
+    echo "doesn't already exist as the code will produce a message and not run otherwise."
+    echo ""
+    echo "The new or benchamrk directory will be created from the 'replacement_directory' folder."
+    echo ""
+    echo "Note: The result is logged in the log file regardless whether they are printed to the"
+    echo "screen and benchmark must be run first."
+    echo ""
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "path/to/test_new_heasoft_install.sh <path/to/w3browse-*.tar> [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo " -h ,  --help                Display this help message"
+    echo " -b*, --benchmark*           Define a benchmark run should be performed or folder"
+    echo "                             name suffix to benchmark<suffix> to be used as a"
+    echo "                             benchmark"
+    echo "                                 - Default is \"benchmark\""
+    echo "                                 - If given an arument then it will be appended to"
+    echo "                                   the benchmark folder name."
+    echo " -n*, --new*                 Define a new run should be performed"
+    echo "                                 - Default is \"new\""
+    echo "                                 - If given an arument then it will become the suffix"
+    echo "                                   to the new run folder name (i.e., \"new<suffix>\")."
+    echo "                                 - If both -b/--benchmark* and -n*/--new* are given"
+    echo "                                   then a new run will be performed with the default"
+    echo "                                   (or otherwise defined) benchmark folder"
+    echo " -g*, --gti-file*            Define a custom GTI file to use"
+    echo "                                 - Default is:"
+    echo "                                   \"$TIME_INTERVAL_FILE\""
+    echo " -ra*, --rega-file*            Define a custom region FPMA file to use"
+    echo "                                 - Default is:"
+    echo "                                   \"$REGION_FILEA\""
+    echo " -rb*, --regb-file*            Define a custom region FPMA file to use"
+    echo "                                 - Default is:"
+    echo "                                   \"$REGION_FILEB\""
+    echo " -o*, --obs-id*              Define a different NuSTAR observation ID"
+    echo "                                 - Default is \"80414202001\""
+    echo "                                 - Must correspond to the <w3browse-*.tar> file that"
+    echo "                                   was downloaded"
+    echo " -p , --print-xspec-result   Set that the final Xspec result should be printed"
+    echo ""
+    echo "Generic Eamples:"
+    echo "## Run HEASoft on your current configuration, store the outputs, then compare with a new,"
+    echo "## future HEASoft configuration (must be run first)"
+    echo "path/to/test_new_heasoft_install.sh <path/to/w3browse-*.tar> -b"
+    echo ""
+    echo "## Compare previous results to those obtained from the new currently installed HEASoft"
+    echo "path/to/test_new_heasoft_install.sh <path/to/w3browse-*.tar> -n"
+    echo ""
+    echo "Other Eamples:"
+    echo ""
+}
 
 # \e[<fg_bg>;5;<ANSI_color_code>m
 # colour for foreground (<fg_bg>=38) or to the background (<fg_bg>=48)
@@ -132,11 +190,108 @@ function normal_lines_end() {
     echo "\n\n" >> $TERM_OUTFILE 2>&1
 }
 
-# set up some file names, hard coded the now
-DOWNLOADED_DATA="w3browse-68892.tar"
-TIME_INTERVAL_FILE="time_gti"
-REGION_FILE="reg_fpm"
-OBSID="80414202001"
+function has_argument() {
+    ## check if the flag has a value
+    [[ ("$1" == *=* && -n ${1#*=}) || ( ! -z "$2" && "$2" != -*)  ]];
+}
+
+function extract_argument() {
+    ## get the value from a flag
+    echo "${2:-${1#*=}}"
+}
+
+# Function to handle options and arguments
+function handle_options() {
+    ## handles the optional inputs to the script
+    while [ $# -gt 0 ]; do
+        case $1 in
+            -h | --help)
+                usage
+                exit 0
+                ;;
+            -b* | --benchmark*)
+                if ! has_argument $@; then
+                    BENCHMARK_DIR="/benchmark"
+                else
+                    BENCHMARK_DIR="/benchmark"$(extract_argument $@)
+                fi
+                ;;
+            -n* | --new*)
+                # Test new configuration
+                TERM_OUTFILE=$SCRIPT_DIR"/test_new_heasoft_install.log"
+                COMPARE_TO_BENCHMARK="yes"
+                echo $BEGIN_STATEMENT"starting HEASoft processing to test against cached examples." | tee $TERM_OUTFILE 2>&1
+
+                if ! has_argument $@; then
+                    HEASOFT_OUTPUT_FILE="/new"
+                else
+                    HEASOFT_OUTPUT_FILE="/new"$(extract_argument $@)
+                fi
+                dir_exist_check $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
+                ;;
+            -g* | --gti-file*)
+                if ! has_argument $@; then
+                    echo "GTI file was not specified." >&2
+                    usage
+                    exit 1
+                fi
+                TIME_INTERVAL_FILE=$(extract_argument $@)
+                ;;
+            -ra* | --rega-file*)
+                if ! has_argument $@; then
+                    echo "Region FPMA file was not specified." >&2
+                    usage
+                    exit 1
+                fi
+                REGION_FILEA=$(extract_argument $@)
+                ;;
+            -rb* | --regb-file*)
+                if ! has_argument $@; then
+                    echo "Region FPMB file was not specified." >&2
+                    usage
+                    exit 1
+                fi
+                REGION_FILEB=$(extract_argument $@)
+                ;;
+            -o* | --obs-id*)
+                if ! has_argument $@; then
+                    echo "Observation ID was not specified." >&2
+                    usage
+                    exit 1
+                fi
+                OBSID=$(extract_argument $@)
+                ;;
+            -p | --print-xspec-result)
+                PRINT_XSPEC_RESULT=1
+                ;;
+        esac
+        shift
+    done
+}
+
+## go through the inputs and set things up
+handle_options "$@"
+
+# if it's a new run, make sure the benchmark dir being pointed to exists
+if [[ $COMPARE_TO_BENCHMARK = "yes" ]] then
+    check_benchmark $BENCHMARK_DIR
+else
+    # Get benchmark for how HEASoft should be
+    # only want to run this is -n is not given
+    TERM_OUTFILE=$SCRIPT_DIR"/run_benchmark_heasoft_install.log"
+    echo $BEGIN_STATEMENT"starting HEASoft install to create cached examples." | tee $TERM_OUTFILE 2>&1
+    $HEASOFT_OUTPUT_FILE=$BENCHMARK_DIR
+    dir_exist_check $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
+fi
+
+# add some stuff to terminal and log files
+echo "Testing will be based on the succesful execution of the code and final XSPEC results." | tee -a $TERM_OUTFILE 2>&1
+echo "Run Date & Time: "$(date +%d.%m.%y-%H:%M:%S) | tee -a $TERM_OUTFILE 2>&1
+
+#  only need dir structure so instead of selecting specific files to keep just delete all and replace with the bones of the structure again
+echo "\n\n" >> $TERM_OUTFILE 2>&1
+cp -R $SCRIPT_DIR"/replacement_directory" $SCRIPT_DIR$HEASOFT_OUTPUT_FILE
+echo "\n\n" >> $TERM_OUTFILE 2>&1
 
 # some other variables
 STATUSEXPR="STATUS==b0000xx00xx0xx000"
@@ -146,10 +301,10 @@ MOVING_STUFF_LINE="Moving stuff around, beep beep."
 # start by moving the data over, unzipping it ready to be used in HEASoft
 echo $MOVING_STUFF_LINE >> $TERM_OUTFILE 2>&1
 normal_line cd $FIRST_FILES_DIR
-normal_line cp "../../raw_nustar_download/$DOWNLOADED_DATA" "./"
-normal_line tar -xf $DOWNLOADED_DATA
+normal_line cp $DOWNLOADED_DATA "./"
+normal_line tar -xf $DOWNLOADED_DATA_FILE
 normal_line gunzip -r $OBSID
-normal_line rm $DOWNLOADED_DATA 
+normal_line rm $DOWNLOADED_DATA_FILE
 normal_line cd $OBSID 
 normal_lines_end
 
@@ -177,8 +332,8 @@ normal_line cd $SCRIPT_DIR$HEASOFT_OUTPUT_FILE"/3-nuscreen-test/"
 normal_lines_end
 
 # filter w.r.t. time and space, testing nuproducts
-test_line "Filter to time and region (FPMA, nuproducts)" "nuproducts indir=./ instrument=FPMA steminputs=nu"$OBSID" outdir=../4-nuproducts-timeAndSpaceSelection-test/ extended=no runmkarf=yes runmkrmf=yes infile=nu"$OBSID"A06_cl_grade0.evt bkgextract=no srcregionfile=../../analysis_selections/region/"$REGION_FILE"a.reg  attfile=./nu"$OBSID"_att.fits hkfile=./nu"$OBSID"A_fpm.hk usrgtifile=../../analysis_selections/good_time_interval/"$TIME_INTERVAL_FILE".fits" 3a
-test_line "Filter to time and region (FPMB, nuproducts)" "nuproducts indir=./ instrument=FPMB steminputs=nu"$OBSID" outdir=../4-nuproducts-timeAndSpaceSelection-test/ extended=no runmkarf=yes runmkrmf=yes infile=nu"$OBSID"B06_cl_grade0.evt bkgextract=no srcregionfile=../../analysis_selections/region/"$REGION_FILE"b.reg  attfile=./nu"$OBSID"_att.fits hkfile=./nu"$OBSID"B_fpm.hk usrgtifile=../../analysis_selections/good_time_interval/"$TIME_INTERVAL_FILE".fits" 3b
+test_line "Filter to time and region (FPMA, nuproducts)" "nuproducts indir=./ instrument=FPMA steminputs=nu"$OBSID" outdir=../4-nuproducts-timeAndSpaceSelection-test/ extended=no runmkarf=yes runmkrmf=yes infile=nu"$OBSID"A06_cl_grade0.evt bkgextract=no srcregionfile="$REGION_FILEA" attfile=./nu"$OBSID"_att.fits hkfile=./nu"$OBSID"A_fpm.hk usrgtifile="$TIME_INTERVAL_FILE 3a
+test_line "Filter to time and region (FPMB, nuproducts)" "nuproducts indir=./ instrument=FPMB steminputs=nu"$OBSID" outdir=../4-nuproducts-timeAndSpaceSelection-test/ extended=no runmkarf=yes runmkrmf=yes infile=nu"$OBSID"B06_cl_grade0.evt bkgextract=no srcregionfile="$REGION_FILEB" attfile=./nu"$OBSID"_att.fits hkfile=./nu"$OBSID"B_fpm.hk usrgtifile="$TIME_INTERVAL_FILE 3b
 
 # take the spectral files outputted and move them to another directory
 echo $MOVING_STUFF_LINE >> $TERM_OUTFILE 2>&1
@@ -215,19 +370,19 @@ if [[ $COMPARE_TO_BENCHMARK = "yes" ]]
 then
     # compare the 'new' HEASoft install to the benchark
     echo $XSPEC_RESULT_LINE >> $TERM_OUTFILE 2>&1
-    normal_line python3 "getXspecParameters.py"  "compare"
+    normal_line python3 "getXspecParameters.py" "compare" "$$BENCHMARK_DIR"
     normal_lines_end
-    if [[ $2 = "print-result" ]]
+    if [[ $PRINT_XSPEC_RESULT = 1 ]]
     then
         echo $XSPEC_RESULT_LINE 
-        python3 "getXspecParameters.py" "compare"
+        python3 "getXspecParameters.py" "compare" "$$BENCHMARK_DIR"
     fi
 else
     # Just run the benchmark so nothing to compare to
     echo $XSPEC_RESULT_LINE >> $TERM_OUTFILE 2>&1
     normal_line python3 "getXspecParameters.py" "no-compare"
     normal_lines_end
-    if [[ $2 = "print-result" ]]
+    if [[ $PRINT_XSPEC_RESULT = 1 ]]
     then
         echo $XSPEC_RESULT_LINE 
         python3 "getXspecParameters.py" "no-compare"


### PR DESCRIPTION
This PR tackles #1 and #2.

For #1, optional shell script flags were introduced so that the downloaded filename can be passed, and should be passed every time. This also means that all the other fixed defaults can now be changed with inputs like the REG/GTI files and even different data can be downloaded and run if the new OBSID is given (obviously will also have to provide new REG/GTI files for this new data as well).

For #2, the XSPEC fit results are always printed to the terminal now as well as logged.

The test can now be run in the git directory as the gitignore stops runs from being tracked.

